### PR TITLE
Add Github Pages' base url to Jekyll

### DIFF
--- a/_binaries/zip.md
+++ b/_binaries/zip.md
@@ -1,5 +1,5 @@
 ---
-description: Most invocations of zip are likely to be vulnerable, as it doesn't support the [end-of-options switch](/remediation) before the archive name.
+description: Most invocations of zip are likely to be vulnerable, as it doesn't support the [end-of-options switch](../../remediation/) before the archive name.
 functions:
   command:
     - description: |

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,7 @@
 title: Argument Injection Vectors
 
+baseurl: /argument-injection-vectors
+
 collections:
   binaries:
     output: true

--- a/_includes/bin_table.html
+++ b/_includes/bin_table.html
@@ -21,7 +21,7 @@
         <tbody>
             {% for file in site.binaries %}
             <tr>
-                <td><a href="{{ file.url }}" class="bin-name">{% include get_bin_name path=file.path %}</a></td>
+                <td><a href="{{ file.url | relative_url }}" class="bin-name">{% include get_bin_name path=file.path %}</a></td>
                 <td>{% include function_list.html bin=file %}</td>
             </tr>
             {% endfor %}

--- a/_includes/function_list.html
+++ b/_includes/function_list.html
@@ -3,6 +3,6 @@
     {% assign function_id = function_pair[0] %}
     {% assign function = function_pair[1] %}
     {% unless include.bin.functions[function_id] %}{% continue %}{% endunless %}
-    <li><a href="{{ include.bin.url }}#{{ function_id }}">{{ function.label }}</a></li>
+    <li><a href="{{ include.bin.url | relative_url }}#{{ function_id }}">{{ function.label }}</a></li>
     {% endfor %}
 </ul>

--- a/_includes/page_title.html
+++ b/_includes/page_title.html
@@ -1,6 +1,6 @@
 <h1>
     {% if page.url != '/' %}
-    <a href="/">..</a> /
+    <a href="{{ site.baseurl }}/">..</a> /
     {% endif %}
     {{ include.title }}
 </h1>

--- a/_layouts/bin.html
+++ b/_layouts/bin.html
@@ -38,7 +38,7 @@ layout: common
 <ul>
 {% for entries in page.functions[function_id] %} 
     {% for ref in entries.references %}
-        <li><a href="{{ ref.url }}">{{ ref.title | markdownify }}</a></li>
+        <li><a href="{{ ref.url | relative_url }}">{{ ref.title | markdownify }}</a></li>
     {% endfor %}
 {% endfor %}
 </ul>

--- a/_layouts/common.html
+++ b/_layouts/common.html
@@ -13,8 +13,8 @@
             {% endif %}
             {{ site.title }}
         </title>
-        <link rel="icon" href="/assets/logo.png">
-        <link rel="stylesheet" href="/assets/style.css" type="text/css"/>
+        <link rel="icon" href="{{ site.baseurl }}/assets/logo.png">
+        <link rel="stylesheet" href="{{ site.baseurl }}/assets/style.css" type="text/css"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes">
     </head>
     <body>

--- a/explained.md
+++ b/explained.md
@@ -26,7 +26,7 @@ It becomes increasingly rare but can still happen in historical software (e.g., 
 
 Arguments passed to a program can be divided into options, option-arguments, and operands as shown in the following picture:
 
-<img src="../assets/arguments.svg" width="500px"/>
+<img src="{{ site.baseurl }}/assets/arguments.svg" width="500px"/>
 
 Any argument that starts with `-` and is not strictly `-` or `--` is called an option. Parsers usually support two forms of options: long ones like `--foo` and short ones like `-f`, where short forms can sometimes be aliases for long forms. Options can expect arguments, for instance, `--foo 1337`, where `--foo` is the option and `1337` the argument. 
 

--- a/explained.md
+++ b/explained.md
@@ -35,7 +35,7 @@ Any argument that starts with `-` and is not strictly `-` or `--` is called an o
 POSIX-compliant argument parsers support a special switch named end-of-options, represented as `--`. 
 All arguments placed after the end-of-options are treated as operands, even if they start with an hyphen (`-`). 
 
-More information on the end-of-options switch to avoid argument injection vulnerabilities can be found on the [Remediation](/remediation/) page.
+More information on the end-of-options switch to avoid argument injection vulnerabilities can be found on the [Remediation]({{ "/remediation/" | relative_url }}) page.
 
 ## Argument Injection
 

--- a/index.md
+++ b/index.md
@@ -9,13 +9,13 @@ Vectors listed below are not vulnerabilities in the associated programs but rath
 
 If you would like to know more on this topic, you can visit:
 
-- [Argument Injections Explained](/explained)
-- [Tools](/tools)
-- [Remediation](/remediation)
+- [Argument Injections Explained]({{ "/explained/" | relative_url }})
+- [Tools]({{ "/tools/" | relative_url }})
+- [Remediation]({{ "/remediation/" | relative_url }})
 
 **Contributing**
 
-[Contributions](/contributing) to this list are very welcome. Feel free to open issues [on the repository](https://github.com/SonarSource/argument-injection-vectors) if you would like to see payloads on a specific program, or a pull request if you are already aware of exploitable flags in a target. Links to public write-ups are appreciated when adding a payload. 
+[Contributions]({{ "/contributing/" | relative_url }}) to this list are very welcome. Feel free to open issues [on the repository](https://github.com/SonarSource/argument-injection-vectors) if you would like to see payloads on a specific program, or a pull request if you are already aware of exploitable flags in a target. Links to public write-ups are appreciated when adding a payload. 
 
 The code of this website is based on [GTFObins](https://gtfobins.github.io/) and is released under GNU General Public License v3.0.
 

--- a/remediation.md
+++ b/remediation.md
@@ -44,7 +44,7 @@ drwxrwxrwt  9 [...] ..
 
 ## Without POSIX-compliant argument parsing
 
-When dealing with programs that do not handle end-of-options, for instance [`zip`](/binaries/zip) and its custom argument parsing, the safest way to proceed is to prefix any user-controlled path by `./` or `/`. 
+When dealing with programs that do not handle end-of-options, for instance [`zip`]({{ "/binaries/zip" | relative_url }}) and its custom argument parsing, the safest way to proceed is to prefix any user-controlled path by `./` or `/`.
 
 See the fix for elFinder's [CVE-2021-32682](https://github.com/Studio-42/elFinder/commit/a106c350b7dfe666a81d6b576816db9fe0899b17#diff-85602823cf2cdaf2502dc4f1b97001ffc0f083652aef175d9f068a5bfe90ca71R6875-R6882 ) for an implementation example.
 


### PR DESCRIPTION
GitHub Pages deploys the project at `https://sonarsource.github.io/argument-injection-vectors/` but Jekyll was not made aware of the directory with the previous PR. 