### PR TITLE
Add reference to CVE-2022-45104

### DIFF
--- a/_binaries/zip.md
+++ b/_binaries/zip.md
@@ -8,6 +8,8 @@ functions:
         When injecting during the archive creation process, two positional arguments
         are required: the destination and a file to compress.
       references:
+        - title: Multiple vulnerabilities in Dell Unisphere for PowerMax vApp, VASA Provider vApp and Solutions Enabler vApp CVE-2022-45103 / CVE-2022-45104
+          url: https://www.synacktiv.com/sites/default/files/2023-02/Synacktiv-Security_Advisory-Dell_EMC_vApp_Manager-Multiple_Vulnerabilities.pdf
         - title: elFinder - A Case Study of Web File Manager Vulnerabilities
           url: https://www.sonarsource.com/blog/elfinder-case-study-of-web-file-manager-vulnerabilities/
       code: zip '-TmTT="$(id>/tmp/foo)foooo".zip' './a.zip' './a.txt'


### PR DESCRIPTION
Dell tracked CVE-2022-45104 as CWE-78 / CWE-77 but it really looks like an argument injection based on [Synacktiv's advisory](https://www.synacktiv.com/sites/default/files/2023-02/Synacktiv-Security_Advisory-Dell_EMC_vApp_Manager-Multiple_Vulnerabilities.pdf).