### PR TITLE
Add a page to show CVEs and their vectors

### DIFF
--- a/cves.md
+++ b/cves.md
@@ -1,0 +1,73 @@
+---
+layout: page
+title: CVEs
+---
+
+<style>
+table {
+    margin: 0 auto;
+}
+</style>
+
+Please have a look at the [Issues tab on GitHub](https://github.com/SonarSource/argument-injection-vectors/issues) to see the status of CVEs being investigated.
+
+## 2022
+
+| CVE   | Project | Vector |
+| :---: | :-----: | :----: |
+| CVE-2022-45104 | Dell Unisphere for PowerMax vApp | [zip]({{ "/binaries/zip/" | relative_url }}) |
+| CVE-2022-39265 | MyBB | [sendmail]({{ "/binaries/sendmail/" | relative_url }}) |
+| CVE-2022-36069 | Poetry | [git-clone]({{ "/binaries/git-clone/" | relative_url }}) |
+| CVE-2022-30129 | Visual Studio Code | [git-clone]({{ "/binaries/git-clone/" | relative_url }}) |
+| CVE-2022-29184 | GoCD | [hg]({{ "/binaries/hg/" | relative_url }}) |
+| CVE-2022-24828 | Composer, Packagist | [hg]({{ "/binaries/hg/" | relative_url }}) |
+| CVE-2022-23915 | Weblate | [hg]({{ "/binaries/hg/" | relative_url }}) |
+
+## 2021
+
+| CVE   | Project | Vector |
+| :---: | :-----: | :----: |
+| CVE-2021-43286 | GoCD | [git-ls-remote]({{ "/binaries/git-ls-remote/" | relative_url }}) |
+| CVE-2021-43809 | Bundler | [git-clone]({{ "/binaries/git-clone/" | relative_url }}) |
+| CVE-2021-38112 | Amazon AWS WorkSpaces | [chrome]({{ "/binaries/chrome/" | relative_url }}) |
+| CVE-2021-32682 | elFinder | [zip]({{ "/binaries/zip/" | relative_url }}) |
+| CVE-2021-29472 | Composer, Packagist | [hg]({{ "/binaries/hg/" | relative_url }}) |
+
+## 2020
+
+| CVE   | Project | Vector |
+| :---: | :-----: | :----: |
+| CVE-2020-17148 | Visual Studio Code Remote Development Extension | [ssh]({{ "/binaries/ssh/" | relative_url }}) |
+
+
+## 2019
+
+| CVE   | Project | Vector |
+| :---: | :-----: | :----: |
+| CVE-2019-14944 | GitLab | [git-log]({{ "/binaries/git-log/" | relative_url }}) |
+| CVE-2019-13139 | Docker | [git-fetch]({{ "/binaries/git-fetch/" | relative_url }}) |
+| CVE-2019-12430 | GitLab | [git-archive]({{ "/binaries/git-archive/" | relative_url }}) |
+| CVE-2019-6739  | Malwarebytes Anti-Malware | [qt5]({{ "/binaries/qt5/" | relative_url }}) |
+| CVE-2019-1636  | Cisco Webex Teams | [qt5]({{ "/binaries/qt5/" | relative_url }}) |
+
+## 2018
+
+| CVE   | Project | Vector |
+| :---: | :-----: | :----: |
+| CVE-2018-1000533 | GitList | [git-grep]({{ "/binaries/git-grep/" | relative_url }}) |
+| CVE-2018-17456 | Git | [git-clone]({{ "/binaries/git-clone/" | relative_url }}) |
+
+## 2017
+
+| CVE   | Project | Vector |
+| :---: | :-----: | :----: |
+| CVE-2017-7692 | SquirrelMail | [sendmail]({{ "/binaries/sendmail/" | relative_url }}) |
+
+## 2016
+
+| CVE   | Project | Vector |
+| :---: | :-----: | :----: |
+| CVE-2016-10074 | SwiftMailer | [sendmail]({{ "/binaries/sendmail/" | relative_url }}) |
+| CVE-2016-10034 | Zend Framework | [sendmail]({{ "/binaries/sendmail/" | relative_url }}) |
+| CVE-2016-10033 | PHPMailer | [sendmail]({{ "/binaries/sendmail/" | relative_url }}) |
+| CVE-2016-9920 | Roundcube | [sendmail]({{ "/binaries/sendmail/" | relative_url }}) |

--- a/index.md
+++ b/index.md
@@ -13,6 +13,8 @@ If you would like to know more on this topic, you can visit:
 - [Tools]({{ "/tools/" | relative_url }})
 - [Remediation]({{ "/remediation/" | relative_url }})
 
+This project also maintains an association between CVEs and vectors on the page [CVEs]({{ "/cves/" | relative_url }}).
+
 **What's the difference with GTFOBins?**
 
 GTFOBins' goal is to "bypass local security restrictions in misconfigured systems", and that's not what we're trying to achieve with our project. We want to provide a list dedicated to helping vulnerability researchers to exploit argument injection bugs. 


### PR DESCRIPTION
This is a PoC of a page that shows public CVEs and the associated exploitation vector. It will help identify the most popular vectors, and I'll add CVEs as I work on them over time.

It would deserve some automation to avoid repeating link templates but I'll deal with that later.